### PR TITLE
Fixed tifffile issue

### DIFF
--- a/vttools/vtmods/io.py
+++ b/vttools/vtmods/io.py
@@ -84,4 +84,4 @@ class ReadTiff(Module):
 
 
 def vistrails_modules():
-    return [ReadNumpy]
+    return [ReadTiff, ReadNumpy]


### PR DESCRIPTION
Fixed pims.extern.tifffile dependency when importing tools to VisTrails.
