### PR TITLE
Comment out xrf_view due to an error

### DIFF
--- a/vttools/vtmods/utils.py
+++ b/vttools/vtmods/utils.py
@@ -160,7 +160,11 @@ def search_databroker(search_dict):
 #                                             unique_id_func=gen_unique_id)
 
 
-from bubblegum.xrf.model.xrf_model import XRF
+# commenting out following part for following reason
+# Get the CSX servers up and running #18 (issue 18 in Nikea/internal)
+# install NSLS2 metapackage into clean conda environment #20
+#  (issue 20 in Nikea/internal)
+"""from bubblegum.xrf.model.xrf_model import XRF
 with enaml.imports():
     from bubblegum.xrf.view.xrf_view import XrfGui
 
@@ -168,9 +172,9 @@ xrf_view = XrfGui()
 xrf_view.xrf_model = XRF()
 
 def setup_bnl_menu():
-    """
-    Creates and hooks up a BNL specific menu in the main window
-    """
+"""
+#Creates and hooks up a BNL specific menu in the main window
+"""
     bw = api.get_builder_window()
     # grab the menu bar
     menu_bar = bw.menuBar()
@@ -184,7 +188,7 @@ def setup_bnl_menu():
         xrf_view.show()
 
 
-    bnl_menu.addAction("demo", foo)
+    bnl_menu.addAction("demo", foo)"""
 
 
 class ForwardingHandler(Handler):
@@ -352,5 +356,5 @@ class Crop2D(Module):
 
 
 def vistrails_modules():
-    setup_bnl_menu()
+    #setup_bnl_menu()
     return [Flatten, Average, SwapAxes, Crop2D]

--- a/vttools/vtmods/utils.py
+++ b/vttools/vtmods/utils.py
@@ -354,7 +354,10 @@ class Crop2D(Module):
 
         self.set_output('bin_mask', im)
 
-
-def vistrails_modules():
+# commenting out following part for following reason
+# Get the CSX servers up and running #18 (issue 18 in Nikea/internal)
+# install NSLS2 metapackage into clean conda environment #20
+#  (issue 20 in Nikea/internal)
+#def vistrails_modules():
     #setup_bnl_menu()
-    return [Flatten, Average, SwapAxes, Crop2D]
+    #return [Flatten, Average, SwapAxes, Crop2D]


### PR DESCRIPTION
@Nikea/development-team  I comment out xrf_view part from the VTTools/vtmods/utils.py. Because it is creating an error when I try to build VTTools and install Nikea stack in CSX server. Please fix it when you need to use it.